### PR TITLE
Added logging (python logging module) and replace sleeps with port polling

### DIFF
--- a/tests/hello_world_test.py
+++ b/tests/hello_world_test.py
@@ -22,22 +22,24 @@ class TestEnvironmentCase(tsqa.test_cases.EnvironmentCase):
 
     # TODO: actually test this, this is currently terrible ;)
     def test_daemon(self):
-        self.environment.start()  # start ATS
-        time.sleep(2)
+        self.log.info('Begin test_daemon')
         assert self.environment.cop.pid > 0
         assert self.environment.cop.returncode is None
-        self.environment.stop()
+        self.log.info('End test_daemon')
 
 class TestDynamicHTTPEndpointCase(tsqa.test_cases.DynamicHTTPEndpointCase):
     def test_base(self):
+        self.log.info('Begin test_base')
         ret = requests.get(self.endpoint_url('/footest'))
         self.assertEqual(ret.status_code, 404)
+        self.log.info('End test_base')
 
     def test_endpoint_url(self):
+        self.log.info('Begin test_endpoint_url')
         assert self.endpoint_url() == 'http://127.0.0.1:{0}'.format(self.http_endpoint.address[1])
 
         assert self.endpoint_url('/foo') == 'http://127.0.0.1:{0}/foo'.format(self.http_endpoint.address[1])
-
+        self.log.info('End test_endpoint_url')
 
 if __name__ == "__main__":
     unittest.main()

--- a/tsqa/test_cases.py
+++ b/tsqa/test_cases.py
@@ -10,7 +10,6 @@ unittest = tsqa.utils.import_unittest()
 
 import os
 
-
 # Example environment case
 class EnvironmentCase(unittest.TestCase):
     '''
@@ -24,6 +23,9 @@ class EnvironmentCase(unittest.TestCase):
     def setUpClass(cls):
         # call parent constructor
         super(EnvironmentCase, cls).setUpClass()
+
+        # get a logger
+        cls.log = tsqa.utils.get_logger()
 
         # get an environment
         cls.environment = cls.getEnv()
@@ -68,6 +70,7 @@ class EnvironmentCase(unittest.TestCase):
         if cls.environment.cop is not None and not cls.environment.running:
             raise Exception('ATS died during the test run')
         # stop ATS
+
         cls.environment.stop()
 
         # call parent destructor
@@ -89,6 +92,9 @@ class DynamicHTTPEndpointCase(unittest.TestCase):
     '''
     @classmethod
     def setUpClass(cls, port=0):
+        # get a logger
+        cls.log = tsqa.utils.get_logger()
+
         cls.http_endpoint = tsqa.endpoint.DynamicHTTPEndpoint(port=port)
         cls.http_endpoint.start()
 

--- a/tsqa/utils.py
+++ b/tsqa/utils.py
@@ -4,6 +4,117 @@ import json
 import sys
 import subprocess
 import socket
+import logging
+import time
+
+tsqa_logger = None
+tsqa_log_level = logging.INFO
+tsqa_log_levels = {
+    'CRITICAL': logging.CRITICAL,
+    'ERROR': logging.ERROR,
+    'WARN': logging.WARNING,
+    'WARNING': logging.WARNING,
+    'INFO': logging.INFO,
+    'DEBUG': logging.DEBUG,
+    'NOTSET': logging.NOTSET
+}
+
+def set_log_level(log_level):
+    '''
+    Set the global log level (override with env var TSQA_LOG_LEVEL).  Must be called
+    before first get_logger()
+    '''
+
+    global tsqa_log_level
+    tsqa_log_level = log_level
+
+def get_log_level():
+    '''
+    Get the global log level (override with env var TSQA_LOG_LEVEL).
+    '''
+
+    if os.environ.has_key('TSQA_LOG_LEVEL'):
+        log_level = os.environ['TSQA_LOG_LEVEL'].upper()
+
+        if tsqa_log_levels.has_key(log_level):
+            return tsqa_log_levels[log_level]
+
+    return tsqa_log_level
+
+def set_logger(logger):
+    '''
+    Set/replace the global logger
+    '''
+
+    global tsqa_logger
+    tsqa_logger = logger
+
+def get_logger():
+    '''
+    Get the global logger
+    '''
+
+    global tsqa_logger
+
+    if tsqa_logger:
+        return tsqa_logger
+
+    tsqa_logger = logging.getLogger()
+    tsqa_logger.setLevel(get_log_level())
+    handler = logging.StreamHandler()
+    handler.setFormatter(logging.Formatter("%(levelname)s %(asctime)-15s - %(message)s"))
+    tsqa_logger.addHandler(handler)
+
+    return tsqa_logger
+
+def poll_interfaces(hostports, **kwargs):
+    '''  Block until we can successfully connect to all ports or timeout
+
+    :param hostports:
+    :param kwargs: optional timeout_sec
+    '''
+
+    connect_timeout_sec = 1
+    poll_sleep_sec = 1
+
+    if kwargs.has_key('timeout_sec'):
+        timeout = time.time() + kwargs['timeout_sec']
+    else:
+        timeout = time.time() + 5
+
+    hostports = hostports[:] # don't modify the caller's hostports
+
+    while timeout > time.time():
+        for hostport in hostports[:]: # don't modify our hostports copy during iteration
+            hostname = hostport[0]
+            port = hostport[1]
+
+            if get_logger().isEnabledFor(logging.DEBUG):
+                get_logger().debug("Checking interface '%s:%d'", hostname, port)
+
+            # This supports IPv6
+
+            try:
+                s = socket.create_connection((hostname, port), timeout=connect_timeout_sec)
+                s.close()
+                hostports.remove(hostport)
+
+                if get_logger().isEnabledFor(logging.DEBUG):
+                    get_logger().debug("Interface '%s:%d' is up", hostname, port)
+            except:
+                pass
+
+        if not hostports:
+            break
+
+        time.sleep(poll_sleep_sec)
+
+    if hostports:
+        raise Exception("Timeout waiting for interfaces: {0}".format(
+                        reduce(lambda x, y: str(x) + ',' + str(y), hostports)))
+
+    if get_logger().isEnabledFor(logging.DEBUG):
+        get_logger().debug("All interfaces are up")
 
 # TODO: test
 def import_unittest():
@@ -37,9 +148,12 @@ def run_sync_command(*args, **kwargs):
     p = subprocess.Popen(*args, **kwargs)
     stdout, stderr = p.communicate()
     if p.returncode != 0:
-        raise Exception('Error running: {0}\n{1}'.format(args[0], stderr))
-    return stdout, stderr
+        if stderr:
+            raise Exception('Error {0} running: {1}\n{2}'.format(p.returncode, args[0], stderr))
+        else:
+            raise Exception('Error {0} running: {1}'.format(p.returncode, args[0]))
 
+    return stdout, stderr
 
 def merge_dicts(*args):
     '''


### PR DESCRIPTION
Note I also removed what appeared to be a superfluous environment.start()/stop() from the example test case which was orphaning a traffic_server process on every test run.