### PR TITLE
fix typo

### DIFF
--- a/tsqa/test_cases.py
+++ b/tsqa/test_cases.py
@@ -23,7 +23,7 @@ class EnvironmentCase(unittest.TestCase):
 
     def run(self, result=None):
         unittest.TestCase.run(self, result)
-        self.__successful &= result.result.wasSuccessful()
+        self.__successful &= result.wasSuccessful()
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Which would cause error: 
   self.__successful &= result.result.wasSuccessful()
AttributeError: 'TextTestResult' object has no attribute 'result'